### PR TITLE
docker; changed backend to use build base for serving for now.

### DIFF
--- a/scripts/backend/Dockerfile
+++ b/scripts/backend/Dockerfile
@@ -16,7 +16,7 @@ FROM build AS publish
 WORKDIR /src/Settings
 RUN dotnet publish -c Release -o /app/published
 
-FROM microsoft/dotnet:2.0-runtime-deps AS production
+FROM microsoft/aspnetcore-build:2.0 AS production
 WORKDIR /app
 COPY --from=publish /app/published .
 RUN rm -rf *.pdb


### PR DESCRIPTION
## Issue 

The runtime-deps container didn't have `dotnet` - so the startup of the backend failed. I tried to change pulblish to `-r linux-64` to generate a self-contained app, but it complained about package version downgrades. We can revisit these options later, but I mostly wanted to ensure app could be built/run. 